### PR TITLE
chat-toolbox.tsx

### DIFF
--- a/src/components/selected-chat/toolbox/chat-toolbox.tsx
+++ b/src/components/selected-chat/toolbox/chat-toolbox.tsx
@@ -62,8 +62,8 @@ const ChatToolbox = (props: HTMLAttributes<HTMLElement>): JSX.Element => {
         chatId: selectedChat.id,
         event: wasHappyEnding ? CHAT_EVENTS.ANSWERED : CHAT_EVENTS.TERMINATED,
         authorTimestamp: new Date().toISOString(),
-        authorFirstName: userLogin,
-        authorId: customerSupportId,
+        authorFirstName: userLogin ? userLogin : 'Bürokratt',
+        authorId: customerSupportId ? customerSupportId : 'bot_institution_id',
         authorRole: AUTHOR_ROLES.BACKOFFICE_USER,
       };
       dispatch(addMessage(terminationMessage));


### PR DESCRIPTION
- [CSA can see agent information in chat history module #13](https://github.com/buerokratt/Customer-service/issues/13)

When conversation being terminated then it would assign a default value of bot if none is currently present.
For example if client spoke only to bot and then closed the conversation in history it would display bot name.
If some one took over the conversation and closed after then that person name would be assigned instead.

Needs to be tested, since in test env we had only one person to test with.